### PR TITLE
New time features, docs, and tests.

### DIFF
--- a/docs/source/user_guide/how_tos/stage_variables.rst
+++ b/docs/source/user_guide/how_tos/stage_variables.rst
@@ -47,8 +47,11 @@ and are listed below:
 * "stage_model": A model to use for Geodetic calculations. See :doc:`geography` for more.
 * "intersection_model": A model to use for motion manager. See :doc:`geography` and :doc:`motion_manager` for more.
 * "time_unit": Units of time. See :py:func:`~upstage_des.units.convert.unit_convert` for a list.
+* "daily_time_count": For non-standard time values, such as "ticks", this number is used to create logging outputs with "Days".
 
 If they are not set and you use a feature that needs them, you'll get a warning about not being able to find a stage variable.
+
+For more information about time units, see :doc:`times`.
 
 
 Accessing Stage through UpstageBase

--- a/docs/source/user_guide/how_tos/times.rst
+++ b/docs/source/user_guide/how_tos/times.rst
@@ -1,0 +1,42 @@
+==========
+Time Units
+==========
+
+At the base level, the UPSTAGE clock (the SimPy clock, really) only cares about the number, and does not care
+about units. This is not people-friendly, especially for debug logging or inputting times in some cases.
+
+UPSTAGE has a few features for dealing with units of time.
+
+The stage variable ``time_unit`` defines what each increment of the clock means. If you don't set it, UPSTAGE assumes
+you mean "hours". When you call for ``pretty_now`` from anything inheriting :py:class:`~upstage_des.base.UpstageBase`,
+you will get a timestamp string like: "Day   3 - 13:06:21". The actor debug logging uses that method on every log action.
+
+If you give a time that isn't standard, such as "clock ticks", you'll get back something like "123.000 clock ticks" if the
+environment time is 123. For non-standard clock times, you can also define how much time passage constitutes a "day". This
+is just a way to track long time passage in a simpler way. If you're simulating logistics on 2D world where there are 125
+"clock ticks" in a day, then setting the stage variable ``daily_time_count`` to 125 will lead to ``pretty_now`` outputs such
+as: "Day   1 - 30 clock ticks" for an environment time of 155.
+
+Wait with units
+===============
+
+The only feature UPSTAGE currently has that uses the time units for controlling the clock is
+the :py:class:`~upstage_des.events.Wait` event. That event takes a ``timeout_unit`` argument that will convert the
+given timeout value from the ``timeout_unit`` into the units defined in ``time_unit`` on the stage. If the unit isn't
+compatible, then an error will be thrown.
+
+Allowable time units
+====================
+
+Time units that UPSTAGE can convert are: seconds, minutes, hours, days, and weeks. The "standard" time values are just
+seconds, minutes, and hours. Any other time unit won't use ``pretty_now`` to output "Day - H:M:S" style. Units that
+aren't part of those times won't work with the ``Wait`` feature for ``timeout_unit``. 
+
+UPSTAGE tries to lowercase your time units, and allow for some flexibility in saying "s", "second", "hr", "hour", "hours",
+and the like. While there are libraries for doing unit conversions, UPSTAGE prefers to have no dependencies other than
+SimPy, so it is restricted in that way. 
+
+See the docstring on :py:func:`~upstage_des.units.convert.unit_convert` for more.
+
+However, all time units are convertible into a single unit on initialization or input data processing, and this is the
+recommended way to run your simulations to ensure your units are correct and consistent.

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -56,6 +56,7 @@ how_tos/active_states.rst
 how_tos/mimic_states.rst
 how_tos/nucleus.rst
 how_tos/stage_variables.rst
+how_tos/times.rst
 how_tos/events.rst
 how_tos/geography.rst
 how_tos/decision_tasks.rst

--- a/docs/source/user_guide/tutorials/first_simulation.rst
+++ b/docs/source/user_guide/tutorials/first_simulation.rst
@@ -58,8 +58,9 @@ The ``scan_speed`` state is defined to require a ``float`` type (UPSTAGE will th
 state is similar, except that a default value of 120 minutes is supplied.
 
 .. note::
-    There is no explicit time dimension in upstage_des. The clock units are up to the user, and the user must ensure that all times are properly defined. If you set a stage variable of ``time_unit``, 
-    it will correct the time for debug logging strings (into hours) only.
+    There is no explicit time dimension in upstage_des. The clock units are up to the user,
+    and the user must ensure that all times are properly defined. See :doc:`Times </user_guide/how_tos/times>`
+    for more, including using time units in ``Wait``.
 
 
 Then you will later instantiate a cashier with [#f1]_:
@@ -74,7 +75,8 @@ Then you will later instantiate a cashier with [#f1]_:
     )
 
 Note that the `name` attribute is required for all UPSTAGE Actors. Also, all inputs are keyword-argument only for an Actor. The ``debug_log`` input is ``False`` by default,
-and when ``True``, you can call ``cashier.log()`` to retrieve an UPSTAGE-generated log of what the actor has been doing.
+and when ``True``, you can call ``cashier.log()`` to retrieve an UPSTAGE-generated log of what the actor has been doing. The same method, when
+given a string, will record the message into the log, along with the default logging that UPSTAGE does.
 
 States are just Python descriptors, so you may access them the same as you would any instance attribute: ``cashier.scan_speed```, e.g.
 

--- a/docs/source/user_guide/tutorials/first_simulation.rst
+++ b/docs/source/user_guide/tutorials/first_simulation.rst
@@ -59,8 +59,8 @@ state is similar, except that a default value of 120 minutes is supplied.
 
 .. note::
     There is no explicit time dimension in upstage_des. The clock units are up to the user,
-    and the user must ensure that all times are properly defined. See :doc:`Times </user_guide/how_tos/times>`
-    for more, including using time units in ``Wait``.
+    and the user must ensure that all times are properly defined. See :doc:`Time Units </user_guide/how_tos/times>`
+    for more, including using time units in :py:class:`~upstage_des.events.Wait`.
 
 
 Then you will later instantiate a cashier with [#f1]_:

--- a/src/upstage_des/actor.py
+++ b/src/upstage_des/actor.py
@@ -126,7 +126,7 @@ class Actor(SettableEnv, NamedUpstageEntity):
         self._is_rehearsing: bool = False
 
         self._debug_logging: bool = debug_log
-        self._debug_log: list[str] = []
+        self._debug_log: list[tuple[float | int, str]] = []
 
         self._state_histories: dict[str, list[tuple[float, Any]]] = {}
 
@@ -861,7 +861,7 @@ class Actor(SettableEnv, NamedUpstageEntity):
         clone._is_rehearsing = True
         return clone
 
-    def log(self, msg: str | None = None) -> list[str] | None:
+    def log(self, msg: str | None = None) -> list[tuple[float | int, str]] | None:
         """Add to the log or return it.
 
         Only adds to log if debug_logging is True.
@@ -875,12 +875,12 @@ class Actor(SettableEnv, NamedUpstageEntity):
         if msg and self._debug_logging:
             ts = self.pretty_now
             msg = f"{ts} {msg}"
-            self._debug_log += [msg]
+            self._debug_log += [(self.env.now, msg)]
         elif msg is None:
             return self._debug_log
         return None
 
-    def get_log(self) -> list[str]:
+    def get_log(self) -> list[tuple[float | int, str]]:
         """Get the debug log.
 
         Returns:

--- a/src/upstage_des/base.py
+++ b/src/upstage_des/base.py
@@ -87,7 +87,11 @@ class StageProtocol(Protocol):
 
     @property
     def time_unit(self) -> str:
-        """Time unit, Treated as 'hr' if not set."""
+        """Time unit, Treated as 'hr' if not set.
+
+        This value modifies ``pretty_now`` from ``UpstageBase``,
+        and can be used to modfy ``Wait`` timeouts.
+        """
 
     @property
     def random(self) -> Random:
@@ -97,8 +101,11 @@ class StageProtocol(Protocol):
     def daily_time_count(self) -> float | int:
         """The number of time_units in a "day".
 
-        If time_unit is s, m, hr, day, week, etc., then
-        this is automatically considered 24.
+        This value only modifies ``pretty_now`` from ``UpstageBase``.
+
+        This is only used if the time_unit is not
+        s, min, or hr. In that case, 24 hour days are
+        assumed.
         """
 
     if TYPE_CHECKING:

--- a/src/upstage_des/task.py
+++ b/src/upstage_des/task.py
@@ -379,8 +379,7 @@ class Task(SettableEnv):
             raise SimulationError("No interrupt behavior returned from `on_interrupt`")
 
         if _interrupt_action in (InterruptStates.END, InterruptStates.RESTART):
-            if actor._debug_logging:
-                actor.log(f"Interrupted by {interrupt}.")
+            actor.log(f"Interrupted by {interrupt}.")
             actor.deactivate_all_states(task=self)
             actor.deactivate_all_mimic_states(task=self)
             if isinstance(next_event, BaseEvent):

--- a/src/upstage_des/test/test_event.py
+++ b/src/upstage_des/test/test_event.py
@@ -9,7 +9,14 @@ from simpy.resources import base
 from simpy.resources.container import ContainerGet, ContainerPut
 from simpy.resources.store import StoreGet, StorePut
 
-from upstage_des.api import Actor, EnvironmentContext, SimulationError, State, Task
+from upstage_des.api import (
+    Actor,
+    EnvironmentContext,
+    SimulationError,
+    State,
+    Task,
+    add_stage_variable,
+)
 from upstage_des.events import (
     All,
     Any,
@@ -49,9 +56,14 @@ def test_wait_event() -> None:
         assert isinstance(ret, SIM.Timeout), "Wait doesn't return a simpy timeout"
         assert ret._delay == timeout, "Incorrect timeout time"
 
+    with EnvironmentContext() as env:
+        add_stage_variable("time_unit", "minutes")
+        wait = Wait(timeout=1.1, timeout_unit="hours")
+        assert wait.timeout == 1.1 * 60
+
     with EnvironmentContext(initial_time=init_time) as env:
         timeout_2 = [1, 3]
-        wait = Wait.from_random_uniform(*timeout_2)
+        wait = Wait.from_random_uniform(timeout_2[0], timeout_2[1])
         ret = wait.as_event()
         assert isinstance(ret, SIM.Timeout), "Wait doesn't return a simpy timeout"
         assert timeout_2[0] <= ret._delay <= timeout_2[1], "Incorrect timeout time"

--- a/src/upstage_des/test/test_stage.py
+++ b/src/upstage_des/test/test_stage.py
@@ -10,8 +10,8 @@ from upstage_des.api import (
     UpstageBase,
     UpstageError,
     add_stage_variable,
-    get_stage_variable,
     get_stage,
+    get_stage_variable,
 )
 from upstage_des.base import clear_top_context, create_top_context
 

--- a/src/upstage_des/test/test_stage.py
+++ b/src/upstage_des/test/test_stage.py
@@ -11,6 +11,7 @@ from upstage_des.api import (
     UpstageError,
     add_stage_variable,
     get_stage_variable,
+    get_stage,
 )
 from upstage_des.base import clear_top_context, create_top_context
 
@@ -47,6 +48,9 @@ def test_contextless_stage() -> None:
     add_stage_variable("example", 1.234)
 
     assert get_stage_variable("example") == 1.234
+
+    stage = get_stage()
+    assert stage.example == 1.234
 
     # dropping into a new context ignores the above
     with EnvironmentContext():

--- a/src/upstage_des/test/test_task.py
+++ b/src/upstage_des/test/test_task.py
@@ -314,7 +314,7 @@ def test_terminal_task_run(
         env.run()
         assert env.now == 0
 
-        assert "The Message" in actor._debug_log[-1]
+        assert "The Message" in actor._debug_log[-1][1]
 
         with pytest.raises(SimulationError, match=".+Cannot interrupt a terminal.+"):
             proc.interrupt()
@@ -326,7 +326,7 @@ def test_terminal_task_run(
         env.run()
         assert env.now == 0
 
-        assert "Entering terminal task:" in actor._debug_log[-1]
+        assert "Entering terminal task:" in actor._debug_log[-1][1]
 
 
 def test_terminal_task_rehearse(

--- a/src/upstage_des/units/convert.py
+++ b/src/upstage_des/units/convert.py
@@ -33,6 +33,17 @@ CONVERSIONS: dict[str, dict[str, float]] = {
 
 DISTANCE_UNITS = ["m", "km", "mi", "nmi", "ft"]
 TIME_UNITS = ["s", "min", "hr", "day", "week"]
+TIME_ALTERNATES = {
+    "seconds": "s",
+    "second": "s",
+    "minute": "min",
+    "minutes": "min",
+    "hour": "hr",
+    "hours": "hr",
+    "days": "day",
+    "weeks": "week",
+}
+STANDARD_TIMES = ["s", "min", "hr"]
 
 # add feet to conversions
 CONVERSIONS["ft"] = {"ft": 1.0, "mi": 1 / 5280.0}
@@ -47,7 +58,17 @@ def unit_convert(value: int | float, units_from: str, units_to: str) -> float:
     """Convert between units of distance and time.
 
     Units must be one of:
-        km, m, mi, nmi, ft, s, min, hr, day, week
+        distance: km, m, mi, nmi, ft
+
+        time:
+
+        * s, second, or seconds  
+        * min, minute, or minutes  
+        * hr, hour, or hours  
+        * day or days  
+        * week or weeks  
+
+    All units are lower-cased on input.
 
     Args:
         value (int | float): Value of "from" unit
@@ -60,7 +81,11 @@ def unit_convert(value: int | float, units_from: str, units_to: str) -> float:
     Returns:
         float: _description_
     """
+    units_fr = units_from.lower()
+    units_t = units_to.lower()
+    units_fr = TIME_ALTERNATES.get(units_fr, units_fr)
+    units_t = TIME_ALTERNATES.get(units_t, units_t)
     try:
-        return value * CONVERSIONS[units_from][units_to]
+        return value * CONVERSIONS[units_fr][units_t]
     except KeyError:
         raise ValueError(f"Cannot convert from {units_from} to {units_to}.")

--- a/src/upstage_des/units/convert.py
+++ b/src/upstage_des/units/convert.py
@@ -62,11 +62,11 @@ def unit_convert(value: int | float, units_from: str, units_to: str) -> float:
 
         time:
 
-        * s, second, or seconds  
-        * min, minute, or minutes  
-        * hr, hour, or hours  
-        * day or days  
-        * week or weeks  
+        * s, second, or seconds
+        * min, minute, or minutes
+        * hr, hour, or hours
+        * day or days
+        * week or weeks
 
     All units are lower-cased on input.
 


### PR DESCRIPTION
Added more features relating to units for time. They are mostly cosmetic/for debug logging. However, time units can now be used in `Wait` events if they are compatible with the stage's time unit.