### PR TITLE
Default kwargs for ResourceState

### DIFF
--- a/docs/source/user_guide/how_tos/resource_states.rst
+++ b/docs/source/user_guide/how_tos/resource_states.rst
@@ -52,10 +52,47 @@ There are several reasons for doing this:
 2. Simplifies actor instantiation. Instead of having to build a store on your own for each actor, the states accept simpler data types and handle the environment for you.
 3. Better default behavior instead of needing a partial or a lambda function in the factory.
 4. Default expectations, such as being frozen.
-5. |State| does not understanding recording of entries or counts in stores or containers.
+5. |State| does not understanding recording of entries or items/counts in stores or containers.
 
 
 In practice, the second and last reasons are the most compelling in our experience.
+
+--------------------------
+Default Resource Arguments
+--------------------------
+
+You can pair setting a default resource with default keyword arguments for its instantiation. This helps
+if you want to have default capacities or initial counts. Use the ``default_kwargs`` input to ``ResourceState``
+to accomplish this. Default arguments are overriden by whatever is passed at actor instantiation.
+
+.. code-block:: python
+
+    class CheckoutLane(UP.Actor):
+        customer_queue = UP.ResourceState[SIM.Store]()
+        magazines = UP.ResourceState[SIM.Container](
+            default = SIM.Container,
+            default_kwargs={"capacity": 50, "init": 25},
+        )
+
+    with UP.EnvironmentContext() as env:
+        lane = CheckoutLane(
+            name="FirstLane",
+            customer_queue={
+                "kind": UP.SelfMonitoringStore,
+                "capacity":10,
+            }
+        )
+        assert lane.magazines.level == 25
+
+        lane2 = CheckoutLane(
+            name="SecondLane",
+            customer_queue={
+                "kind": UP.SelfMonitoringStore,
+                "capacity":10,
+            },
+            magazines = {"init": 10},
+        )
+        assert lane2.magazines.level == 10
 
 -----------------------
 Instantiation Arguments

--- a/src/upstage_des/test/test_state.py
+++ b/src/upstage_des/test/test_state.py
@@ -369,7 +369,3 @@ def test_matching_states() -> None:
         assert state_name is not None
         value = getattr(worker, state_name)
         assert value is worker.walkie, "Wrong state retrieved"
-
-
-if __name__ == "__main__":
-    test_resource_state_default_init()

--- a/src/upstage_des/test/test_state.py
+++ b/src/upstage_des/test/test_state.py
@@ -212,14 +212,29 @@ def test_resource_state_no_default_init() -> None:
 def test_resource_state_default_init() -> None:
     class Holder(Actor):
         res = ResourceState[Store](default=Store)
+        res2 = ResourceState[Container](
+            default=Container, default_kwargs={"capacity": 11, "init": 5}
+        )
+
+    class HolderBad(Actor):
+        res = ResourceState[Store](default=Store)
+        res2 = ResourceState[Container](default=Container, default_kwargs={"capa": 11, "init": 5})
 
     with EnvironmentContext():
         h = Holder(name="Example")
         assert isinstance(h.res, Store)
+        assert h.res2.capacity == 11
+        assert h.res2.level == 5
 
-        h = Holder(name="Example", res={"capacity": 10})
+        h = Holder(name="Example", res={"capacity": 10}, res2={"capacity": 12})
         assert isinstance(h.res, Store)
         assert h.res.capacity == 10
+        assert h.res2.capacity == 12
+        assert h.res2.level == 5
+
+        hb = HolderBad(name="Bad one")
+        with pytest.raises(UpstageError):
+            hb.res2.capacity
 
 
 def test_resource_state_kind_init() -> None:
@@ -354,3 +369,7 @@ def test_matching_states() -> None:
         assert state_name is not None
         value = getattr(worker, state_name)
         assert value is worker.walkie, "Wrong state retrieved"
+
+
+if __name__ == "__main__":
+    test_resource_state_default_init()


### PR DESCRIPTION
### Changes

1. Added the ability to set default instantiation kwargs for the containers/stores created with `ResourceState`