### PR TITLE
State data recording fixes

### DIFF
--- a/src/upstage_des/actor.py
+++ b/src/upstage_des/actor.py
@@ -89,8 +89,10 @@ class Actor(SettableEnv, NamedUpstageEntity):
         exist = set(self._state_defs.keys())
         unseen = exist - seen
         for state_name in unseen:
-            if self._state_defs[state_name].has_default():
+            _state = self._state_defs[state_name]
+            if _state.has_default():
                 seen.add(state_name)
+                _state._set_default(self)
         if len(seen) != len(exist):
             raise UpstageError(
                 f"Missing values for states! These states need values: "

--- a/src/upstage_des/data_utils.py
+++ b/src/upstage_des/data_utils.py
@@ -77,8 +77,8 @@ def _actor_state_data(
 
     for state_name, state in actor._state_defs.items():
         if skip_locations and isinstance(state, LOCATION_TYPES):
-            break
-        _value = actor.__dict__[state_name]  # skips data recording after the fact
+            continue
+        _value = actor.__dict__[state_name]
         is_active = isinstance(state, ActiveState)
         if state_name in actor._state_histories:
             data.extend(

--- a/src/upstage_des/test/test_data_reporting.py
+++ b/src/upstage_des/test/test_data_reporting.py
@@ -17,6 +17,7 @@ class Cashier(UP.Actor):
 class Cart(UP.Actor):
     location = UP.CartesianLocationChangingState(recording=True)
     location_two = UP.CartesianLocationChangingState(recording=True)
+    holding = UP.State[float](default=0.0, recording=True)
 
 
 def test_data_reporting() -> None:
@@ -117,14 +118,19 @@ def test_data_reporting() -> None:
     assert ctr[("Ertha", "Cashier", "items_scanned")] == 5
     assert ctr[("Ertha", "Cashier", "cue")] == 4
     assert ctr[("Ertha", "Cashier", "cue2")] == 4
-    assert ctr[("Ertha", "Cashier", "time_working")] == 5
+    assert ctr[("Ertha", "Cashier", "time_working")] == 6
     assert ctr[("Bertha", "Cashier", "items_scanned")] == 2
     assert ctr[("Bertha", "Cashier", "cue")] == 4
     assert ctr[("Bertha", "Cashier", "cue2")] == 4
-    assert ctr[("Bertha", "Cashier", "time_working")] == 4
+    assert ctr[("Bertha", "Cashier", "time_working")] == 5
     assert ctr[("Store Test", "SelfMonitoringFilterStore", "Resource")] == 3
-    assert not any(x[0] == "Wobbly Wheel" for x in state_table)
-    assert len(state_table) == 35
+    # Test for default values untouched in the sim showing up in the data.
+    assert ctr[("Wobbly Wheel", "Cart", "holding")] == 1
+    row = [r for r in state_table if r[:3] == ("Wobbly Wheel", "Cart", "holding")][0]
+    assert row[4] == 0
+    assert row[3] == 0.0
+    # Continuing as before
+    assert len(state_table) == 38
     assert cols == all_cols
     assert cols == [
         "Entity Name",
@@ -139,15 +145,16 @@ def test_data_reporting() -> None:
     assert ctr[("Ertha", "Cashier", "items_scanned")] == 5
     assert ctr[("Ertha", "Cashier", "cue")] == 4
     assert ctr[("Ertha", "Cashier", "cue2")] == 4
-    assert ctr[("Ertha", "Cashier", "time_working")] == 5
+    assert ctr[("Ertha", "Cashier", "time_working")] == 6
     assert ctr[("Bertha", "Cashier", "items_scanned")] == 2
     assert ctr[("Bertha", "Cashier", "cue")] == 4
     assert ctr[("Bertha", "Cashier", "cue2")] == 4
-    assert ctr[("Bertha", "Cashier", "time_working")] == 4
+    assert ctr[("Bertha", "Cashier", "time_working")] == 5
     assert ctr[("Store Test", "SelfMonitoringFilterStore", "Resource")] == 3
+    assert ctr[("Wobbly Wheel", "Cart", "holding")] == 1
     assert ctr[("Wobbly Wheel", "Cart", "location")] == 4
     assert ctr[("Wobbly Wheel", "Cart", "location_two")] == 4
-    assert len(all_state_table) == 35 + 8
+    assert len(all_state_table) == 38 + 8
 
     assert loc_cols == [
         "Entity Name",
@@ -170,3 +177,7 @@ def test_data_reporting() -> None:
         0.0,
         "inactive",
     )
+
+
+if __name__ == "__main__":
+    test_data_reporting()

--- a/src/upstage_des/test/test_state.py
+++ b/src/upstage_des/test/test_state.py
@@ -19,9 +19,6 @@ from upstage_des.type_help import SIMPY_GEN
 class StateTest:
     state_one = State[Any]()
     state_two = State[Any](recording=True)
-    lister = State[list](default=[])
-    diction = State[dict](default={})
-    setstate = State[set](default=set())
 
     def __init__(self, env: Environment | None) -> None:
         cast(UP.Actor, self)
@@ -42,6 +39,12 @@ class StateTestActor(Actor):
     state_one = State[Any]()
     state_two = State[Any](recording=True)
     state_three = LinearChangingState(recording=True)
+
+
+class MutableDefaultActor(Actor):
+    lister = State[list](default=[])
+    diction = State[dict](default={})
+    setstate = State[set](default=set())
 
 
 def test_state_fails_without_env() -> None:
@@ -77,23 +80,23 @@ def test_state_recording() -> None:
 
 
 def test_state_mutable_default() -> None:
-    with EnvironmentContext(initial_time=1.5) as env:
-        tester = StateTest(env)
-        tester2 = StateTest(env)
-        assert id(tester.lister) != id(tester2.lister)  # type: ignore [arg-type]
-        tester.lister.append(1)  # type: ignore [arg-type]
-        assert len(tester2.lister) == 0  # type: ignore [arg-type]
-        assert len(tester.lister) == 1  # type: ignore [arg-type]
+    with EnvironmentContext(initial_time=1.5):
+        tester = MutableDefaultActor(name="Example")
+        tester2 = MutableDefaultActor(name="Example2")
+        assert id(tester.lister) != id(tester2.lister)
+        tester.lister.append(1)
+        assert len(tester2.lister) == 0
+        assert len(tester.lister) == 1
 
-        assert id(tester.diction) != id(tester2.diction)  # type: ignore [arg-type]
-        tester2.diction[1] = 2  # type: ignore [arg-type]
-        assert len(tester.diction) == 0  # type: ignore [arg-type]
-        assert len(tester2.diction) == 1  # type: ignore [arg-type]
+        assert id(tester.diction) != id(tester2.diction)
+        tester2.diction[1] = 2
+        assert len(tester.diction) == 0
+        assert len(tester2.diction) == 1
 
-        assert id(tester.setstate) != id(tester2.setstate)  # type: ignore [arg-type]
-        tester2.setstate.add(1)  # type: ignore [arg-type]
-        assert len(tester.setstate) == 0  # type: ignore [arg-type]
-        assert len(tester2.setstate) == 1  # type: ignore [arg-type]
+        assert id(tester.setstate) != id(tester2.setstate)
+        tester2.setstate.add(1)
+        assert len(tester.setstate) == 0
+        assert len(tester2.setstate) == 1
 
 
 def test_state_values_from_init() -> None:
@@ -232,9 +235,8 @@ def test_resource_state_default_init() -> None:
         assert h.res2.capacity == 12
         assert h.res2.level == 5
 
-        hb = HolderBad(name="Bad one")
         with pytest.raises(UpstageError):
-            hb.res2.capacity
+            HolderBad(name="Bad one")
 
 
 def test_resource_state_kind_init() -> None:
@@ -339,7 +341,7 @@ def test_matching_states() -> None:
     """
 
     class Worker(UP.Actor):
-        sleepiness = UP.State(default=0, valid_types=(float,))
+        sleepiness = UP.State[float](default=0.0, valid_types=(float,))
         walkie = UP.CommunicationStore(mode="UHF")
         intercom = UP.CommunicationStore(mode="loudspeaker")
 


### PR DESCRIPTION
1. Opted to make the state's instantiation non-lazy - the `Actor` has the state set the default right away
2. Default setting of the state goes right to recording as well
3. Fixed the continue vs break bug
4. Fixed a `DetectabilityState` bug revealed by changes. The motion manager call happened when the initial state setting went to the recording method, but that's a case where the motion manager doesn't need to know.