### PR TITLE
#26 - Added None as allowable default to states.

### DIFF
--- a/docs/source/user_guide/how_tos/states.rst
+++ b/docs/source/user_guide/how_tos/states.rst
@@ -1,0 +1,45 @@
+======
+States
+======
+
+States are a core UPSTAGE feature that gives :py:meth:`~upstage_des.actor.Actor` classes their useful and
+changeable data. There are advanced state features, such as :doc:`Active States <active_states>` and
+:doc:`Resource States <resource_states>`.
+
+The :py:class:`~upstage_des.states.State` class is a python
+`descriptor <https://docs.python.org/3/howto/descriptor.html>`_. This provides hooks for getting and setting
+values stored on the Actor instance under the name of the state while allowing configuration, data recording,
+and other features.
+
+Plain states are created as follows, with nearly all the arguments shown for the state creation:
+
+.. code-block::python
+
+    import ustage_des.api as UP
+
+    class Cashier(UP.Actor):
+        friendliness = UP.State[float](
+            valid_types=(float,),
+            recording=True,
+            default=1.0,
+            frozen = False,
+            record_duplicates = False,
+            allow_none_default = False,
+        )
+
+Note the typing of the ``State``, which tells your IDE and ``mypy`` what to expect out.
+
+State inputs:
+
+1. ``valid_types``: Types that the state can take for runtime checks. This may be removed in the future.
+2. ``recording``: If the state records every time its value changes.
+3. ``default``: A default value to use for the state. This allows the actor to be instantiated without it.
+4. ``frozen``: If ``True``, any attempt to set the state value throws an exception (default ``False``).
+5. ``record_duplicates``: If recording, allow duplicates to be recorded (default ``False``).
+6. ``allow_none_default``: If ``True``, the state can have no default value set and not throw the exception.
+7. ``default_factory``: Not shown, but provide a function to create the default value. Useful for mutable defaults.
+
+The ``allow_none_default`` input is useful if you won't have access to the information needed to set a state when
+your Actor is instantiated. This is common when you need actors to have mutual references to each other, for example.
+
+If you set a default and a default factory, UPSTAGE will use the default and ignore the factory.

--- a/docs/source/user_guide/how_tos/states.rst
+++ b/docs/source/user_guide/how_tos/states.rst
@@ -13,7 +13,7 @@ and other features.
 
 Plain states are created as follows, with nearly all the arguments shown for the state creation:
 
-.. code-block::python
+.. code-block:: python
 
     import ustage_des.api as UP
 
@@ -26,6 +26,7 @@ Plain states are created as follows, with nearly all the arguments shown for the
             record_duplicates = False,
             allow_none_default = False,
         )
+
 
 Note the typing of the ``State``, which tells your IDE and ``mypy`` what to expect out.
 

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -54,6 +54,7 @@ These pages detail the specific activities that can be accomplished using UPSTAG
 :maxdepth: 1
 
 how_tos/environment.rst
+how_tos/states.rst
 how_tos/resources.rst
 how_tos/resource_states.rst
 how_tos/active_states.rst

--- a/src/upstage_des/test/test_state.py
+++ b/src/upstage_des/test/test_state.py
@@ -116,6 +116,20 @@ def test_state_values_from_init() -> None:
         assert tester._state_histories["state_three"] == [(0.0, 4), (1.5, 3)]
 
 
+def test_state_none_allowed() -> None:
+    class NoneActor(Actor):
+        example = State[int](allow_none_default=True)
+
+    with EnvironmentContext():
+        ex = NoneActor(name="Example")
+
+        with pytest.raises(SimulationError, match="State example should have been set"):
+            ex.example
+
+        ex.example = 3
+        assert ex.example == 3
+
+
 def test_linear_changing_state() -> None:
     state_three_init = 3
     init_time = 1.5


### PR DESCRIPTION
`State` now has a parameter `allow_none_default` which can be set to `True`. This will still raise an error if you access the unset state, but it will let you get past `Actor` initialization without giving a value to the start.

This is for convenience/flexibility in initialization.