### PR TITLE
41 wait event doesnt create on init

### DIFF
--- a/src/upstage_des/events.py
+++ b/src/upstage_des/events.py
@@ -332,6 +332,7 @@ class Put(BaseRequestEvent):
 
         self.put_location = put_location
         self.put_object = put_object
+        self._request_event: ContainerPut | StorePut | None = None
 
     def as_event(self) -> ContainerPut | StorePut:
         """Convert event to a ``simpy`` Event.
@@ -342,7 +343,8 @@ class Put(BaseRequestEvent):
             Put request as a simpy event.
 
         """
-        self._request_event = self.put_location.put(self.put_object)
+        if self._request_event is None:
+            self._request_event = self.put_location.put(self.put_object)
         return self._request_event
 
 
@@ -563,6 +565,7 @@ class Get(BaseRequestEvent):
         self.get_args = get_args
         self.get_kwargs = get_kwargs
         self.__is_store = issubclass(get_location.__class__, SIM.Store)
+        self._request_event: ContainerGet | StoreGet | None = None
 
     def calculate_time_to_complete(self) -> float:
         """Calculate time elapsed until the event is triggered.
@@ -580,10 +583,11 @@ class Get(BaseRequestEvent):
             ContainerGet | StoreGet
         """
         # TODO: optional checking for container types for feasibility
-        self._request_event = self.get_location.get(
-            *self.get_args,
-            **self.get_kwargs,
-        )
+        if self._request_event is None:
+            self._request_event = self.get_location.get(
+                *self.get_args,
+                **self.get_kwargs,
+            )
         return self._request_event
 
     def get_value(self) -> tyAny:

--- a/src/upstage_des/events.py
+++ b/src/upstage_des/events.py
@@ -206,6 +206,7 @@ class Wait(BaseEvent):
             raise SimulationError(f"Negative timeout in Wait: {self._time_to_complete}")
         rehearse = timeout if rehearsal_time_to_complete is None else rehearsal_time_to_complete
         super().__init__(rehearsal_time_to_complete=rehearse)
+        self._simpy_event: SIM.Timeout | None = None
 
     @classmethod
     def from_random_uniform(
@@ -242,7 +243,8 @@ class Wait(BaseEvent):
             SIM.Timeout
         """
         assert isinstance(self.env, SIM.Environment)
-        self._simpy_event = self.env.timeout(self._time_to_complete)
+        if self._simpy_event is None:
+            self._simpy_event = self.env.timeout(self._time_to_complete)
         return self._simpy_event
 
     def cancel(self) -> None:


### PR DESCRIPTION
### Changes

1. Made `UP.Wait` retain the timeout to match simpy behavior
2. Made `Get` and `Put` events also not hide their events on a second `yield`.