### PR TITLE
Non-recording state output in data reports.

### DIFF
--- a/docs/source/user_guide/tutorials/data.rst
+++ b/docs/source/user_guide/tutorials/data.rst
@@ -313,6 +313,9 @@ There are two functions for gathering data from UPSTAGE:
      if the state has an active status.
    * If ``skip_locations`` is set to ``False``, then location objects
      will go into the state value column.
+   * If ``save_static`` is set to ``True``, then non-recording states
+     will have their last value recorded in the table with an ``Activation Status``
+     column value of ``"Last Seen"``.
    * Data are in long-form, meaning rows may share a timestamp.
 
 2. :py:func:`upstage_des.data_utils.create_location_table`
@@ -342,12 +345,14 @@ following table (a partial amount shown) would be obtained from the ``create_tab
     +-----------+-------------------------+-------------+----+-----+-----------------+
     |Ertha      |Cashier                  |time_working |   3|  2.9|active           |
     +-----------+-------------------------+-------------+----+-----+-----------------+
+    |Ertha      |Cashier                  |other        |   0|  3.0|Last Seen        |
+    +-----------+-------------------------+-------------+----+-----+-----------------+
     |Bertha     |Cashier                  |cue          |   0|  0.0|                 |
     +-----------+-------------------------+-------------+----+-----+-----------------+
     |Bertha     |Cashier                  |cue2         |   0|  0.0|                 |
     +-----------+-------------------------+-------------+----+-----+-----------------+
     |Bertha     |Cashier                  |time_working |   0|  0.0|inactive         |
-    +-----------+-------------------------+-------------+----+-----+-----------------+
+    +-----------+-------------------------+-------------+----+-----+-----------------+    
     |Store Test |SelfMonitoringFilterStore|Resource     |   0|  0.0|                 |
     +-----------+-------------------------+-------------+----+-----+-----------------+
 

--- a/src/upstage_des/test/test_data_reporting.py
+++ b/src/upstage_des/test/test_data_reporting.py
@@ -59,8 +59,8 @@ def test_data_reporting() -> None:
             c.items_scanned += 1
             c.cue.put("A")
             c.cue2.put(10)
-            c.other = 3.0
             c.time_working = 0.0
+        cash.other = 3.0
 
         cart.activate_location_state(
             state="location",
@@ -133,6 +133,8 @@ def test_data_reporting() -> None:
         state_table, cols = create_table()
         all_state_table, all_cols = create_table(skip_locations=False)
         loc_state_table, loc_cols = create_location_table()
+        new_table, _ = create_table(skip_locations=True, save_static=True)
+        orig_table, _ = create_table(skip_locations=True, save_static=False)
 
     ctr = Counter([row[:3] for row in state_table])
     assert ctr[("Ertha", "Cashier", "items_scanned")] == 5
@@ -203,6 +205,17 @@ def test_data_reporting() -> None:
         0.0,
         "inactive",
     )
+
+    match1 = ("Ertha", "Cashier", "other", 0.0, 3.0, "Last Seen")
+    assert match1 in new_table
+    assert match1 not in all_state_table
+
+    match2 = ("Bertha", "Cashier", "other", 0.0, 0.0, "Last Seen")
+    assert match2 in new_table
+    assert match2 not in all_state_table
+
+    # Only the two "other" states should show up
+    assert len(new_table) - len(orig_table) == 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The parameter `save_static` in `data_utils.create_table` will save out non-recording states' value at the time of the function call.