### PR TITLE
Cancelling Knowledge Events on interrupt

### DIFF
--- a/docs/source/user_guide/how_tos/knowledge.rst
+++ b/docs/source/user_guide/how_tos/knowledge.rst
@@ -130,4 +130,5 @@ method to support this activity (also described in :doc:`Events </user_guide/how
 The above simplified example shows how UPSTAGE tasks can work with knowledge events to
 support simple releases from other tasks without adding stores or other signaling mechanisms.
 
-The succeed event method also clears the event from the knowledge.
+The succeed event method also clears the event from the knowledge. If a task is interrupted
+on a knowledge event, the event is cancelled and the knowledge is cleared.

--- a/src/upstage_des/task.py
+++ b/src/upstage_des/task.py
@@ -452,6 +452,10 @@ class Task(SettableEnv):
             actor.deactivate_all_states(task=self)
             actor.deactivate_all_mimic_states(task=self)
             if isinstance(next_event, BaseEvent):
+                names = list(actor._knowledge.keys())
+                for name in names:
+                    if actor._knowledge[name] is next_event:
+                        actor.clear_knowledge(name, caller=f"Clearing knowledge event {name}")
                 next_event.cancel()
             elif isinstance(next_event, Process):
                 next_event.interrupt(cause=interrupt.cause)

--- a/src/upstage_des/test/test_knowledge.py
+++ b/src/upstage_des/test/test_knowledge.py
@@ -1,0 +1,46 @@
+import upstage_des.api as UP
+from upstage_des.type_help import TASK_GEN
+
+
+class KnowEvenTask(UP.Task):
+    def task(self, *, actor: UP.Actor) -> TASK_GEN:
+        evt = actor.create_knowledge_event(name="EvtName")
+        self.set_actor_knowledge(actor, "finished", False)
+        yield evt
+        self.set_actor_knowledge(actor, "finished", True, overwrite=True)
+
+    def on_interrupt(self, *, actor: UP.Actor, cause: str) -> UP.InterruptStates:
+        self.set_actor_knowledge(actor, "cause", cause)
+        return UP.InterruptStates.END
+
+
+def test_knowledge_event_clear() -> None:
+    with UP.EnvironmentContext() as env:
+        act = UP.Actor(name="Example")
+
+        task = KnowEvenTask()
+        task.run(actor=act)
+
+        env.run()
+        assert not act._knowledge["finished"]
+        act.succeed_knowledge_event(name="EvtName")
+        env.run()
+        assert act._knowledge["finished"]
+        assert "EvtName" not in act._knowledge
+
+    with UP.EnvironmentContext() as env:
+        act = UP.Actor(name="Example")
+
+        task = KnowEvenTask()
+        proc = task.run(actor=act)
+
+        env.run()
+        assert not act._knowledge["finished"]
+        proc.interrupt(cause="ending")
+        env.run()
+
+        assert "EvtName" not in act._knowledge
+
+
+if __name__ == "__main__":
+    test_knowledge_event_clear()

--- a/src/upstage_des/test/test_knowledge.py
+++ b/src/upstage_des/test/test_knowledge.py
@@ -38,8 +38,9 @@ def test_knowledge_event_clear() -> None:
         assert not act._knowledge["finished"]
         proc.interrupt(cause="ending")
         env.run()
-
         assert "EvtName" not in act._knowledge
+        assert not act._knowledge["finished"]
+        assert act._knowledge["cause"] == "ending"
 
 
 if __name__ == "__main__":

--- a/src/upstage_des/test/test_knowledge.py
+++ b/src/upstage_des/test/test_knowledge.py
@@ -5,6 +5,7 @@ from upstage_des.type_help import TASK_GEN
 class KnowEvenTask(UP.Task):
     def task(self, *, actor: UP.Actor) -> TASK_GEN:
         evt = actor.create_knowledge_event(name="EvtName")
+        actor.create_knowledge_event(name="other evt")
         self.set_actor_knowledge(actor, "finished", False)
         yield evt
         self.set_actor_knowledge(actor, "finished", True, overwrite=True)
@@ -27,6 +28,7 @@ def test_knowledge_event_clear() -> None:
         env.run()
         assert act._knowledge["finished"]
         assert "EvtName" not in act._knowledge
+        assert "other evt" in act._knowledge
 
     with UP.EnvironmentContext() as env:
         act = UP.Actor(name="Example")
@@ -41,6 +43,8 @@ def test_knowledge_event_clear() -> None:
         assert "EvtName" not in act._knowledge
         assert not act._knowledge["finished"]
         assert act._knowledge["cause"] == "ending"
+        # Only the yielded event should be cleared.
+        assert "other evt" in act._knowledge
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added a check to clear knowledge from an actor if the knowledge holds a yielded event. 