### PR TITLE
Updating State default behavior

### DIFF
--- a/docs/source/user_guide/how_tos/states.rst
+++ b/docs/source/user_guide/how_tos/states.rst
@@ -43,4 +43,4 @@ State inputs:
 The ``allow_none_default`` input is useful if you won't have access to the information needed to set a state when
 your Actor is instantiated. This is common when you need actors to have mutual references to each other, for example.
 
-If you set a default and a default factory, UPSTAGE will use the default and ignore the factory.
+If you set a default and a default factory, UPSTAGE will raise an error to force you to pick one or the other.

--- a/src/upstage_des/test/test_state.py
+++ b/src/upstage_des/test/test_state.py
@@ -42,9 +42,9 @@ class StateTestActor(Actor):
 
 
 class MutableDefaultActor(Actor):
-    lister = State[list](default=[])
-    diction = State[dict](default={})
-    setstate = State[set](default=set())
+    lister = State[list](default_factory=list)
+    diction = State[dict](default_factory=dict)
+    setstate = State[set](default_factory=set)
 
 
 def test_state_fails_without_env() -> None:
@@ -385,3 +385,7 @@ def test_matching_states() -> None:
         assert state_name is not None
         value = getattr(worker, state_name)
         assert value is worker.walkie, "Wrong state retrieved"
+
+
+if __name__ == "__main__":
+    test_state_mutable_default()


### PR DESCRIPTION
State `default` and `default_factory` inputs were deepcopied, and the factory was never re-run for a new `Actor` instance.

Now:

1. States can only have one: default or a factory
2. The factory is always run on each state initialization
3. If a default value is given, that's the value used. No deepcopy is used on it any more.

This should motivate better practices (using factories for mutable types) in UPSTAGE.