### PR TITLE
27 create recording functions

### DIFF
--- a/src/upstage_des/states.py
+++ b/src/upstage_des/states.py
@@ -166,7 +166,7 @@ class State(Generic[ST]):
 
         for func, name in self._recording_functions:
             result = func(*to_append)
-            if self.name not in instance._state_histories:
+            if name not in instance._state_histories:
                 instance._state_histories[name] = []
             instance._state_histories[name].append((now, result))
 


### PR DESCRIPTION
Created the capability for recording functions to be supplied to states. Those functions (or classes that implement a `__call__` of the right format) will create additional datapoints for state histories.

Recording functions and classes, when called, must accept the time and state value. Whatever they return is recorded at the same time, under a defined name. The data from the recording functions follows the same duplication rule that the state they are attached to follows. 