### PR TITLE
Comms modes are runtime-definable

### DIFF
--- a/docs/source/user_guide/how_tos/communications.rst
+++ b/docs/source/user_guide/how_tos/communications.rst
@@ -10,11 +10,16 @@ and off on a point to point basis.
 
 The :py:class:`~upstage_des.communications.comms.Message` class is used to
 describe a message, although strings and dictionaries can also be passed as
-messages, and UPSTAGE will convert them into the ``Message`` class.
+messages, and UPSTAGE will convert them into the ``Message`` class. The 
+message will include information about the sender, mode, and other data.
 
 The communications manager needs to be instantiated and run, and any number
-of them can be run, to represent different modes of communication. The
-following code shows how create an actor class that has two communication
+of them can be run to represent different modes of communication. For 
+simplicity, communications stores on an actor can have multiple modes
+to receive communications on. Each mode needs its own manager which can
+then determine the right store to send the message to. 
+
+The following code shows how create an actor class that has two communication
 interfaces, and then start the necessary comms managers.
 
 .. code-block:: python

--- a/docs/source/user_guide/how_tos/communications.rst
+++ b/docs/source/user_guide/how_tos/communications.rst
@@ -2,24 +2,28 @@
 Communications
 ==============
 
-UPSTAGE provides a built-in method for passing communications between actors. The :py:class:`~upstage_des.communications.comms.CommsManager` class
-allows actors to send messages while allowing for simplified retry attempts and timeouts. It also allows for communications
-blocking to be turned on and off on a point to point basis.
+UPSTAGE provides a built-in method for passing communications between actors.
+The :py:class:`~upstage_des.communications.comms.CommsManager` class
+allows actors to send messages while allowing for simplified retry attempts
+and timeouts. It also allows for communications blocking to be turned on
+and off on a point to point basis.
 
-The :py:class:`~upstage_des.communications.comms.Message` class is used to describe a message, although strings and dictionaries can
-also be passed as messages, and UPSTAGE will convert them into the ``Message`` class.
+The :py:class:`~upstage_des.communications.comms.Message` class is used to
+describe a message, although strings and dictionaries can also be passed as
+messages, and UPSTAGE will convert them into the ``Message`` class.
 
-The communications manager needs to be instantiated and run, and any number of them can be run, to represent different modes of
-communication. The following code shows how create an actor class that has two communication interfaces, and then start the necessary
-comms managers.
+The communications manager needs to be instantiated and run, and any number
+of them can be run, to represent different modes of communication. The
+following code shows how create an actor class that has two communication
+interfaces, and then start the necessary comms managers.
 
 .. code-block:: python
 
     import upstage_des.api as UP
 
     class Worker(UP.Actor):
-        walkie = UP.CommunicationStore(mode="UHF")
-        intercom = UP.CommunicationStore(mode="loudspeaker")
+        walkie = UP.CommunicationStore(modes=["UHF"])
+        intercom = UP.CommunicationStore(modes=["loudspeaker"])
 
     
     with UP.EnvironmentContext() as env:
@@ -35,11 +39,14 @@ comms managers.
         uhf_comms.run()
         loudspeaker_comms.run()
 
-The ``CommsManager`` class allows for explicitly connecting actors and the store that will receive messages, but using the
-:py:class:`~upstage_des.states.CommunicationStore` lets the manager auto-discover the proper store for a communications mode, letting
-the simulation designer only need to pass the source actor, destination actor, and message information to the manager.
+The ``CommsManager`` class allows for explicitly connecting actors and the
+store that will receive messages, but using the :py:class:`~upstage_des.states.CommunicationStore`
+lets the manager auto-discover the proper store for a communications mode,
+letting the simulation designer only need to pass the source actor, destination
+actor, and message information to the manager.
 
-To send a message, use the comm manager's ``make_put`` method to return an UPSTAGE event to yield on to send the message.
+To send a message, use the comm manager's ``make_put`` method to return an UPSTAGE
+event to yield on to send the message.
 
 .. code-block:: python
 

--- a/src/upstage_des/test/test_comms.py
+++ b/src/upstage_des/test/test_comms.py
@@ -186,8 +186,8 @@ def test_comms_wait() -> None:
 
 
 class Worker(UP.Actor):
-    walkie = UP.CommunicationStore(mode="UHF")
-    intercom = UP.CommunicationStore(mode="loudspeaker")
+    walkie = UP.CommunicationStore(modes="UHF")
+    intercom = UP.CommunicationStore(modes="loudspeaker")
 
 
 def test_worker_talking() -> None:

--- a/src/upstage_des/test/test_comms.py
+++ b/src/upstage_des/test/test_comms.py
@@ -212,4 +212,6 @@ def test_worker_talking() -> None:
 
         env.run()
         assert len(w2.walkie.items) == 1
+        assert w2.walkie.items[0].mode == "UHF"
         assert len(w1.intercom.items) == 1
+        assert w1.intercom.items[0].mode == "loudspeaker"

--- a/src/upstage_des/test/test_comms.py
+++ b/src/upstage_des/test/test_comms.py
@@ -186,7 +186,7 @@ def test_comms_wait() -> None:
 
 
 class Worker(UP.Actor):
-    walkie = UP.CommunicationStore(modes="UHF")
+    walkie = UP.CommunicationStore(modes=["UHF", "other"])
     intercom = UP.CommunicationStore(modes="loudspeaker")
 
 

--- a/src/upstage_des/test/test_state.py
+++ b/src/upstage_des/test/test_state.py
@@ -358,19 +358,20 @@ def test_matching_states() -> None:
 
     class Worker(UP.Actor):
         sleepiness = UP.State[float](default=0.0, valid_types=(float,))
-        walkie = UP.CommunicationStore(mode="UHF")
-        intercom = UP.CommunicationStore(mode="loudspeaker")
+        walkie = UP.CommunicationStore(modes="UHF")
+        intercom = UP.CommunicationStore(modes="loudspeaker")
 
     with EnvironmentContext():
         worker = Worker(name="Billy")
         store_name = worker._get_matching_state(
             UP.CommunicationStore,
-            {"_mode": "loudspeaker"},
+            {"_modes": "loudspeaker"},
         )
         assert store_name is not None
         store = getattr(worker, store_name, "")
         assert store is worker.intercom, "Wrong state retrieved"
         assert store is not worker.walkie, "Wrong state retrieved"
+        assert getattr(worker, "_intercom__mode_names_") == set(["loudspeaker"])
 
         # Show the FCFS behavior
         state_name = worker._get_matching_state(

--- a/src/upstage_des/test/test_state.py
+++ b/src/upstage_des/test/test_state.py
@@ -358,7 +358,7 @@ def test_matching_states() -> None:
 
     class Worker(UP.Actor):
         sleepiness = UP.State[float](default=0.0, valid_types=(float,))
-        walkie = UP.CommunicationStore(modes="UHF")
+        walkie = UP.CommunicationStore(modes=["UHF", "loudspeaker"])
         intercom = UP.CommunicationStore(modes="loudspeaker")
 
     with EnvironmentContext():
@@ -372,6 +372,7 @@ def test_matching_states() -> None:
         assert store is worker.intercom, "Wrong state retrieved"
         assert store is not worker.walkie, "Wrong state retrieved"
         assert getattr(worker, "_intercom__mode_names_") == set(["loudspeaker"])
+        assert getattr(worker, "_walkie__mode_names_") == set(["UHF", "loudspeaker"])
 
         # Show the FCFS behavior
         state_name = worker._get_matching_state(


### PR DESCRIPTION
This PR allows `CommunicationStore` states to have the mode set at instantiation, rather than forced to be defined in the actor definition. Multiple modes (as strings) can be given.

```python
class TalkingActor(UP.Actor):
    messages = UP.CommunicationStore(modes=None)
    
with UP.EnvironmentContext():
    ta = TalkingActor(name="talker", messages={"modes": ["vocal", "sign language"]})
```