### PR TITLE
Initialize Knowledge and No Init States

### DIFF
--- a/docs/source/user_guide/how_tos/knowledge.rst
+++ b/docs/source/user_guide/how_tos/knowledge.rst
@@ -16,6 +16,12 @@ continuation patterns, described farther below.
 
 Knowledge is accessed and updated through:
 
+* In ``Actor`` instantiation
+  
+  * Use the ``initial_knowledge`` keyword argument when creating your actor.
+
+  * Pass a dictionary to set as knowledge.
+
 * :py:meth:`upstage_des.actor.Actor.get_knowledge`
 
   * ``name``: The name of the knowledge.

--- a/docs/source/user_guide/how_tos/states.rst
+++ b/docs/source/user_guide/how_tos/states.rst
@@ -35,15 +35,21 @@ State inputs:
 1. ``valid_types``: Types that the state can take for runtime checks. This may be removed in the future.
 2. ``recording``: If the state records every time its value changes.
 3. ``default``: A default value to use for the state. This allows the actor to be instantiated without it.
-4. ``frozen``: If ``True``, any attempt to set the state value throws an exception (default ``False``).
-5. ``record_duplicates``: If recording, allow duplicates to be recorded (default ``False``).
-6. ``allow_none_default``: If ``True``, the state can have no default value set and not throw the exception.
-7. ``default_factory``: Not shown, but provide a function to create the default value. Useful for mutable defaults.
+4. ``no_init``: If ``True``, keep the state out of the Actor's init, and raise an error if it's input.
+5. ``frozen``: If ``True``, any attempt to set the state value throws an exception (default ``False``).
+6. ``record_duplicates``: If recording, allow duplicates to be recorded (default ``False``).
+7. ``allow_none_default``: If ``True``, the state can have no default value set and not throw the exception.
+8. ``default_factory``: Not shown, but provide a function to create the default value. Useful for mutable defaults.
 
 The ``allow_none_default`` input is useful if you won't have access to the information needed to set a state when
 your Actor is instantiated. This is common when you need actors to have mutual references to each other, for example.
 
 If you set a default and a default factory, UPSTAGE will raise an error to force you to pick one or the other.
+
+The ``no_init`` input requires a default to be set. The purpose of this setting is to hint to the user that
+the state shouldn't be initialized to anything other than the value given by the default settings. This
+is useful for states that act like counters and should always start at a default value. If the state
+receives an input on initialization, and error will be thrown.
 
 Some states do not use all these parameters, so consult the specific documentation for more.
 

--- a/src/upstage_des/states.py
+++ b/src/upstage_des/states.py
@@ -94,6 +94,7 @@ class State(Generic[ST]):
         *,
         default: ST | None = None,
         frozen: bool = False,
+        no_init: bool = False,
         valid_types: type | tuple[type, ...] | None = None,
         recording: bool = False,
         record_duplicates: bool = False,
@@ -121,6 +122,7 @@ class State(Generic[ST]):
         Args:
             default (Any | None, optional): Default value of the state. Defaults to None.
             frozen (bool, optional): If the state is allowed to change. Defaults to False.
+            no_init (bool, optional): Ignore the state in the init and rely on the default.
             valid_types (type | tuple[type, ...] | None, optional): Types allowed. Defaults to None.
             recording (bool, optional): If the state records itself. Defaults to False.
             record_duplicates (bool, optional): If the state records duplicate values.
@@ -139,7 +141,11 @@ class State(Generic[ST]):
 
         if self._default is not None and self._default_factory is not None:
             raise UpstageError("State needs to only use default or default factory.")
+        any_def = self._default is not None or self._default_factory is not None
 
+        self._no_init = no_init
+        if self._no_init and not any_def:
+            raise SimulationError("State needs a default for no_init=True")
         self._frozen = frozen
         self._recording = recording
         self._record_duplicates = record_duplicates


### PR DESCRIPTION
1. Actors can take `initial_knowledge` as a keyword argument during initialization and set knowledge based on the key:values of that parameter.
2. States can set `no_init=True` in their creation. This prevents the state from being in init docs and from having its value set to anything other than the default during initialization. This is useful for States meant for counters or other data trackers that always have a clean starting point.