### PR TITLE
117 complete task testing

### DIFF
--- a/src/upstage_des/api.py
+++ b/src/upstage_des/api.py
@@ -32,6 +32,7 @@ from upstage_des.events import (
     Put,
     ResourceHold,
     Wait,
+    WaitUntil,
 )
 from upstage_des.states import (
     LinearChangingState,
@@ -76,4 +77,5 @@ __all__ = [
     "Task",
     "TASK_GEN",
     "SIMPY_GEN",
+    "WaitUntil",
 ]

--- a/src/upstage_des/events.py
+++ b/src/upstage_des/events.py
@@ -278,25 +278,25 @@ class Wait(BaseEvent):
     def __init__(
         self,
         timeout: float | int,
-        timeout_unit: str | None = None,
+        time_unit: str | None = None,
         *,
         rehearsal_time_to_complete: float | int | None = None,
     ) -> None:
         """Create a timeout event.
 
-        If timeout_unit is specified, UPSTAGE will try to convert it to the
+        If time_unit is specified, UPSTAGE will try to convert it to the
         time_unit set in the stage. Otherwise, it defaults to that time unit.
 
         Args:
             timeout (float | int): Time to wait.
-            timeout_unit (str, optional): Units of time
+            time_unit (str, optional): Units of time
             rehearsal_time_to_complete (float | int, optional): The rehearsal time
                 to complete. Defaults to None (the timeout given).
 
         """
         if not isinstance(timeout, float | int):
             raise SimulationError("Bad timeout. Did you mean to use from_random_uniform?")
-        timeout = self._convert_time(timeout, timeout_unit)
+        timeout = self._convert_time(timeout, time_unit)
         self._time_to_complete = timeout
         self.timeout = timeout
         if self._time_to_complete < 0:
@@ -310,19 +310,19 @@ class Wait(BaseEvent):
         cls,
         low: float | int,
         high: float | int,
-        timeout_unit: str | None = None,
+        time_unit: str | None = None,
         *,
         rehearsal_time_to_complete: float | int | None = None,
     ) -> "Wait":
         """Create a wait from a random uniform time.
 
-        If timeout_unit is specified, UPSTAGE will try to convert it to the
+        If time_unit is specified, UPSTAGE will try to convert it to the
         time_unit set in the stage. Otherwise, it defaults to that time unit.
 
         Args:
             low (float): Lower bounds of random draw
             high (float): Upper bounds of random draw
-            timeout_unit (str, optional): Units of time
+            time_unit (str, optional): Units of time
             rehearsal_time_to_complete (float | int, optional): The rehearsal time
                 to complete. Defaults to None - meaning the random value drawn.
 
@@ -331,10 +331,90 @@ class Wait(BaseEvent):
         """
         rng = UpstageBase().stage.random
         timeout = rng.uniform(low, high)
-        return cls(timeout, timeout_unit, rehearsal_time_to_complete=rehearsal_time_to_complete)
+        return cls(timeout, time_unit, rehearsal_time_to_complete=rehearsal_time_to_complete)
 
     def as_event(self) -> SIM.Timeout:
         """Cast Wait event as a simpy Timeout event.
+
+        Returns:
+            SIM.Timeout
+        """
+        assert isinstance(self.env, SIM.Environment)
+        if self._simpy_event is None:
+            self._simpy_event = self.env.timeout(self._time_to_complete)
+        return self._simpy_event
+
+    def cancel(self) -> None:
+        """Cancel the timeout.
+
+        There's no real meaning to cancelling a timeout. It sits in simpy's queue either way.
+        """
+        assert self._simpy_event is not None
+        try:
+            self._simpy_event.defused = True
+        except RuntimeError as exc:
+            warn(f"Runtime error when cancelling '{self}', Error: {exc}!")
+
+
+class WaitUntil(BaseEvent):
+    """Wait until a specific clock time.
+
+    Rehearsal time is given by the maximum time of the interval, if given.
+
+    Parameters
+    ----------
+    time : int, float
+        Time to wait until
+    """
+
+    def _convert_time(self, time: float | int, unit: str | None) -> float:
+        """Convert a time to the stage time.
+
+        Args:
+            time (float | int): The current time
+            unit (str): Units the time is in
+
+        Returns:
+            float: Time in stage units
+        """
+        base_unit = self.stage.time_unit
+        if base_unit is not None and unit is not None:
+            return unit_convert(time, unit, base_unit)
+        return time
+
+    def __init__(
+        self,
+        until: float | int,
+        time_unit: str | None = None,
+        *,
+        rehearsal_time_to_complete: float | int | None = None,
+    ) -> None:
+        """Create a timeout event.
+
+        If timeout_unit is specified, UPSTAGE will try to convert it to the
+        time_unit set in the stage. Otherwise, it defaults to that time unit.
+
+        Args:
+            until (float | int): Time to wait.
+            time_unit (str, optional): Units of time
+            rehearsal_time_to_complete (float | int, optional): The rehearsal time
+                to complete. Defaults to None (the timeout given).
+
+        """
+        if not isinstance(until, float | int):
+            raise SimulationError("Bad timeout. Must ve numeric")
+        until_time = self._convert_time(until, time_unit)
+        timeout = until_time - self.env.now
+        self._time_to_complete = timeout
+        self.timeout = timeout
+        if self._time_to_complete < 0:
+            raise SimulationError(f"Negative timeout in WaitUntil: {self._time_to_complete}")
+        rehearse = timeout if rehearsal_time_to_complete is None else rehearsal_time_to_complete
+        super().__init__(rehearsal_time_to_complete=rehearse)
+        self._simpy_event: SIM.Timeout | None = None
+
+    def as_event(self) -> SIM.Timeout:
+        """Cast WaitUntil event as a simpy Timeout event.
 
         Returns:
             SIM.Timeout

--- a/src/upstage_des/tasks.py
+++ b/src/upstage_des/tasks.py
@@ -10,7 +10,6 @@ from enum import IntFlag
 from typing import Any, TypeVar
 from warnings import warn
 
-from simpy import Environment as SimpyEnv
 from simpy import Event as SimpyEvent
 from simpy import Interrupt, Process
 
@@ -251,7 +250,6 @@ class DecisionTask(Task):
             Generator[SimpyEvent, None, None]: Generator for SimPy event queue.
         """
         self.make_decision(actor=actor)
-        assert isinstance(self.env, SimpyEnv)
         yield self.env.timeout(0.0)
 
     def run_skip(self, *, actor: "Actor") -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -26,6 +26,7 @@ from upstage_des.events import (
     Put,
     ResourceHold,
     Wait,
+    WaitUntil,
 )
 from upstage_des.base import SIMPY_GEN, Stage
 
@@ -57,7 +58,7 @@ def test_wait_event() -> None:
 
     stage = Stage(time_unit="minutes")
     with EnvironmentContext(stage=stage) as env:
-        wait = Wait(timeout=1.1, timeout_unit="hours")
+        wait = Wait(timeout=1.1, time_unit="hours")
         assert wait.timeout == pytest.approx(66)
 
     with EnvironmentContext(initial_time=init_time) as env:
@@ -78,6 +79,26 @@ def test_wait_event() -> None:
 
         with pytest.raises(SimulationError):
             Wait(timeout=[1, 2, 3])  # type: ignore [arg-type]
+
+
+def test_wait_until_event() -> None:
+    init_time = 1.23
+    with EnvironmentContext(initial_time=init_time) as env:
+        timeout = 1
+        until = init_time+timeout
+        wait = WaitUntil(until=until)
+        assert wait.created_at == init_time, "Problem in environment time being stored in event"
+        assert wait.env is env, "Problem in environment being stored in event"
+        assert wait.timeout == timeout
+
+        ret = wait.as_event()
+        assert isinstance(ret, SIM.Timeout), "Wait doesn't return a simpy timeout"
+        assert ret._delay == timeout, "Incorrect timeout time"
+
+    stage = Stage(time_unit="minutes")
+    with EnvironmentContext(stage=stage) as env:
+        wait = WaitUntil(until=1.1, time_unit="hours")
+        assert wait.timeout == pytest.approx(66)
 
 
 def test_base_request_event() -> None:

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -51,8 +51,9 @@ def test_knowledge() -> None:
         v = ma.get_knowledge("number")
         assert v is EMPTY_KNOWLEDGE
         ma.set_knowledge("number", 12.0, caller="The Test")
-        assert ma.get_knowledge("number", must_exist=True) == 12.0
-        assert len(ma.get_log()) == 2
+        assert ma.get_and_clear_knowledge("number") == 12.0
+        assert len(ma.get_log()) == 3
+        assert "number" not in ma.knowledge
 
 
 test_knowledge()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -408,3 +408,7 @@ def test_terminal_task_run(
         task._final_interrupt = True
         proc.interrupt(cause="FINAL")
         env.run()
+
+
+def test_markers() -> None:
+    assert False

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -9,13 +9,13 @@ from inspect import isgeneratorfunction
 from typing import Any, TypedDict, cast
 
 import pytest
-from simpy import Environment, Process
+from simpy import Environment, Interrupt, Process
 
 from upstage_des.actor import Actor
 from upstage_des.base import SIMPY_GEN, EnvironmentContext, SimulationError
 from upstage_des.events import Wait
 from upstage_des.states import LinearChangingState, State
-from upstage_des.tasks import InterruptStates, Task, TASK_GEN, TerminalTask
+from upstage_des.tasks import DecisionTask, InterruptStates, Task, TASK_GEN, TerminalTask
 
 class Know(TypedDict):
     thing1: str
@@ -411,4 +411,133 @@ def test_terminal_task_run(
 
 
 def test_markers() -> None:
-    assert False
+    class MarkedTask(Task):
+        def task(self, *, actor: Actor):
+            self.set_marker("First", InterruptStates.IGNORE)
+            yield Wait(1.0)
+            self.clear_marker()
+            self.set_marker("Second", InterruptStates.RESTART)
+            yield Wait(3.0)
+            self.set_marker("Third", InterruptStates.END)
+            yield Wait(3.0)
+
+    with EnvironmentContext(initial_time=0.1) as env:
+        act = Actor(name="test")
+        t = MarkedTask()
+        proc = t.run(actor=act)
+        marker = t.get_marker()
+        assert marker is None
+        env.run(until=0.4)
+        marker = t.get_marker()
+        assert marker == "First"
+        time = t.get_marker_time()
+        assert time == 0.1
+        assert t._interrupt_action is InterruptStates.IGNORE
+        # Interrupt!
+        proc.interrupt()
+        env.run(until=1.2)
+        assert t.get_marker() == "Second"
+        assert t.get_marker_time() == 1.1
+        assert t._interrupt_action is InterruptStates.RESTART
+        # Interrupt!
+        proc.interrupt()
+        env.run(until=1.3)
+        assert t.get_marker() == "First"
+        assert t.get_marker_time() == 1.2
+        env.run(until=2.3)
+        assert t.get_marker() == "Second"
+        env.run(until=5.3)
+        assert t.get_marker() == "Third"
+
+
+def test_interrupt_process() -> None:
+    data = []
+    def proc(env, t: float):
+        data.append("start")
+        try:
+            yield env.timeout(t)
+            data.append("done")
+        except Interrupt as e:
+            data.append(e.cause)
+
+    def proc_bad(env, t: float):
+        data.append("start")
+        yield env.timeout(t)
+        data.append("done")
+
+    class ProcTask(Task):
+        def task(self, *, actor: Actor):
+            _p = self.env.process(proc(self.env, 2.1))
+            yield _p
+
+    class ProcTaskBad(Task):
+        def task(self, *, actor: Actor):
+            _p = self.env.process(proc_bad(self.env, 2.1))
+            yield _p
+
+    with EnvironmentContext() as env:
+        act = Actor(name="example")
+        t = ProcTask()
+        p = t.run(actor=act)
+        env.run(until=1.3)
+        assert data[0] == "start"
+        p.interrupt(cause="CAUSE")
+        env.run()
+        assert data[-1] == "CAUSE"
+
+    with EnvironmentContext() as env:
+        act = Actor(name="example")
+        t = ProcTaskBad()
+        p = t.run(actor=act)
+        env.run(until=1.3)
+        assert data[0] == "start"
+        p.interrupt(cause="CAUSE")
+        with pytest.raises(Interrupt):
+            env.run()
+
+
+def test_decision_task() -> None:
+    class DT(DecisionTask):
+        def make_decision(self, *, actor: Actor):
+            self.set_actor_knowledge(
+                actor,
+                "exam",
+                "HERE",
+            )
+    
+    with EnvironmentContext() as env:
+        act = Actor(name="Example")
+        dt = DT()
+        dt.run(actor=act)
+        env.run()
+        assert env.now == 0
+        assert act.get_and_clear_knowledge("exam") == "HERE"
+
+
+def test_task_knowledge() -> None:
+    class KnowTask2(Task):
+        def task(self, *, actor: Actor):
+            self.set_actor_bulk_knowledge(
+                actor=actor,
+                know={"ONE": 1, "TWO": 2.0}
+            )
+            yield Wait(1.0)
+            z = self.get_and_clear_actor_knowledge(actor, "ONE")
+            assert z == 1
+            yield Wait(1.0)
+            ans = self.get_and_clear_actor_bulk_knowledge(actor, names=["TWO"])
+            assert ans == {"TWO": 2}
+
+    with EnvironmentContext() as env:
+        act = Actor(name="Example")
+        kt2 = KnowTask2()
+        kt2.run(actor=act)
+        env.run(until=0.8)
+        assert "ONE" in act.knowledge
+        assert "TWO" in act.knowledge
+        env.run(until=1.2)
+        assert "ONE" not in act.knowledge
+        assert "TWO" in act.knowledge
+        env.run(until=2.2)
+        assert "ONE" not in act.knowledge
+        assert "TWO" not in act.knowledge


### PR DESCRIPTION
# Updates:

1. Added a `WaitUntil` event for convenience. Give it the time you want to stop at, rather than an amount of time to wait.
2. Testing `DecisionTask`
3. Testing task knowledge clearing
4. Testing markers and interrupts with markers.